### PR TITLE
Eliminate some of Dialyzer's underspec warnings

### DIFF
--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -966,10 +966,11 @@ proper_list(ElementType) ->
 
 %% Constructs a new list type based on another, optionally keeping the same
 %% length and/or making it proper.
--spec copy_list(List, Length, Proper) -> type() when
+-spec copy_list(List, Length, Proper) -> CopiedList when
       List :: type(),
       Length :: same_length | new_length,
-      Proper :: proper | maybe_improper.
+      Proper :: proper | maybe_improper,
+      CopiedList :: #t_cons{} | #t_list{} | nil.
 copy_list(#t_cons{terminator=Term}=T, Length, maybe_improper) ->
     copy_list_1(T, Length, Term);
 copy_list(#t_list{terminator=Term}=T, Length, maybe_improper) ->

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -40,9 +40,11 @@
 
 -type index()        :: non_neg_integer().
 -type literals()     :: 'none' | gb_trees:tree(index(), term()).
--type symbolic_tag() :: 'a' | 'f' | 'h' | 'i' | 'u' | 'x' | 'y' | 'z'.
--type disasm_tag()   :: symbolic_tag() | 'fr' | 'atom' | 'float' | 'literal'.
--type disasm_term()  :: 'nil' | {disasm_tag(), _}.
+-type primitive_tag() :: 'a' | 'f' | 'h' | 'i' | 'u' | 'x' | 'y'.
+-type symbolic_tag() :: primitive_tag() | 'z'.
+-type disasm_tag()   :: primitive_tag() | 'fr' | 'float'.
+-type all_disasm_tag() :: disasm_tag() | 'atom' | 'literal'.
+-type disasm_term()  :: 'nil' | {all_disasm_tag(), _}.
 
 %%-----------------------------------------------------------------------
 

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -65,8 +65,7 @@
 -type b_switch()   :: #b_switch{}.
 -type terminator() :: b_br() | b_ret() | b_switch().
 
--type construct()  :: b_module() | b_function() | b_blk() | b_set() |
-                      terminator().
+-type anno_construct() :: b_function() | b_blk() | b_set() | terminator().
 
 -type b_var()      :: #b_var{}.
 -type b_literal()  :: #b_literal{}.
@@ -136,7 +135,7 @@
 -spec add_anno(Key, Value, Construct) -> Construct when
       Key :: atom(),
       Value :: any(),
-      Construct :: construct().
+      Construct :: anno_construct().
 
 add_anno(Key, Val, #b_function{anno=Anno}=Bl) ->
     Bl#b_function{anno=Anno#{Key=>Val}};
@@ -151,12 +150,12 @@ add_anno(Key, Val, #b_ret{anno=Anno}=Bl) ->
 add_anno(Key, Val, #b_switch{anno=Anno}=Bl) ->
     Bl#b_switch{anno=Anno#{Key=>Val}}.
 
--spec get_anno(atom(), construct()) -> any().
+-spec get_anno(atom(), anno_construct()) -> any().
 
 get_anno(Key, Construct) ->
     map_get(Key, get_anno(Construct)).
 
--spec get_anno(atom(), construct(),any()) -> any().
+-spec get_anno(atom(), anno_construct(),any()) -> any().
 
 get_anno(Key, Construct, Default) ->
     maps:get(Key, get_anno(Construct), Default).

--- a/lib/compiler/src/beam_ssa_lint.erl
+++ b/lib/compiler/src/beam_ssa_lint.erl
@@ -38,7 +38,7 @@ module(#b_module{body=Fs,name=Name}=Mod0, _Options) ->
             {error,[{atom_to_list(Name), Es}]}
     end.
 
--spec format_error(term()) -> iolist().
+-spec format_error({mfa(),term()}) -> iolist().
 format_error({{_M,F,A},Error}) ->
     [io_lib:format("~p/~p: ", [F,A]),format_error_1(Error)].
 

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -66,7 +66,9 @@
 
 %%
 
--spec opt_start(term(), term()) -> term().
+-spec opt_start(StMap, FuncDb) -> {StMap, FuncDb} when
+      StMap :: st_map(),
+      FuncDb :: func_info_db().
 opt_start(StMap, FuncDb0) when FuncDb0 =/= #{} ->
     {ArgDb, FuncDb} = signatures(StMap, FuncDb0),
 

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -600,13 +600,14 @@ make_float(Float) when is_float(Float) ->
 make_float(Min, Max) when is_float(Min), is_float(Max), Min =< Max ->
     #t_float{elements={Min, Max}}.
 
--spec make_integer(integer()) -> type().
+-spec make_integer(integer()) -> #t_integer{}.
 make_integer(Int) when is_integer(Int) ->
     make_integer(Int, Int).
 
--spec make_integer(Min, Max) -> type() when
+-spec make_integer(Min, Max) -> IntegerType when
       Min :: integer(),
-      Max :: integer().
+      Max :: integer(),
+      IntegerType :: #t_integer{}.
 make_integer(Min, Max) when is_integer(Min), is_integer(Max), Min =< Max ->
     #t_integer{elements={Min,Max}}.
 


### PR DESCRIPTION
This PR fixes 6 of the underspec warnings in the compiler application.

I have not fixed this warning:

```
rec_env.erl:99:2: Type specification rec_env:empty
          () -> environment() is a supertype of the success typing: rec_env:empty
          () -> [{'map', #{}}, ...]
```

because I am not sure how to do that in a clean way. It seems silly to define and export an `empty_environment()` type.