### PR TITLE
Clean up size calculation for binary_to_term/1

### DIFF
--- a/erts/emulator/test/binary_SUITE.erl
+++ b/erts/emulator/test/binary_SUITE.erl
@@ -1545,11 +1545,14 @@ test_terms(Test_Func) ->
     Test_Func("abcdef"),
     Test_Func([a, b, 1, 2]),
     Test_Func([a|b]),
+    Test_Func([make_port(), make_ref(), make_pid(), fun() -> ok end,
+               Very_Big | lists:seq(1, 75)]),
 
     Test_Func({}),
     Test_Func({1}),
     Test_Func({a, b}),
     Test_Func({a, b, c}),
+    Test_Func({make_port(), make_ref(), make_pid(), fun() -> ok end}),
     Test_Func(list_to_tuple(lists:seq(0, 255))),
     Test_Func(list_to_tuple(lists:seq(0, 256))),
 
@@ -1600,9 +1603,11 @@ test_terms(Test_Func) ->
     Test_Func(<<42:10>>),
     Test_Func(list_to_bitstring([<<5:6>>|lists:seq(0, 255)])),
 
+    %% Funs in a list.
     Test_Func(F = fun(A) -> 42*A end),
     Test_Func(lists:duplicate(32, F)),
 
+    %% External funs in a list.
     Test_Func(FF = fun binary_SUITE:all/0),
     Test_Func(lists:duplicate(32, FF)),
 


### PR DESCRIPTION
This commit cleans up the size calculation phase of binary_to_term/1:

* Count sub terms in an **unsigned** 32-bit integer instead of in
  an **signed** 32-bit integer to ensure that the counter wraps on
  overflow. While the existing code worked on all platform we have
  tested it on, signed overflow is is undefined behavior in the C
  standard.

* Be paranoid and use the overflow-checking ADDTERM() macro for **all**
  additions to the `term` variable.

* Reject lists and large tuples early if the rest of the binary being
  decoded is obviously too short. (The same early rejection was already
  done for maps.)

* Explicitly reject decoding maps with 2^31 or more elements. Decoding
  maps with that many elements has never worked correctly, but would
  fail in random ways (because the `term` variable would overflow and
  miscount the sub terms).

We considered counting sub terms in a 64-bit counter on 64-bit machines
to allow truly ginormous terms to be decoded, but decided that such terms
are probably a mistake and that it is better to reject them.